### PR TITLE
Fix disappearing authors in old tasks

### DIFF
--- a/app/models/task.js
+++ b/app/models/task.js
@@ -11,8 +11,8 @@ export default DS.Model.extend( {
     }),
 
     title: DS.attr("string"),
-    author: DS.belongsTo("user", { async: true }),
-    co_author: DS.belongsTo("user", { async: true }),
+    author: DS.belongsTo("user", { async: true, inverse: null }),
+    co_author: DS.belongsTo("user", { async: true, inverse: null }),
     intro: DS.attr("string"),
     max_score: DS.attr("number"),
 


### PR DESCRIPTION
This PR fixes an old bug, when for old tasks the author and co_author were disappering.
Closes #351