### PR TITLE
restore highlight for `import`; add highlight for builtin

### DIFF
--- a/app/styles/base/code.scss
+++ b/app/styles/base/code.scss
@@ -130,7 +130,7 @@ code span.al { color: #ff0000; font-weight: bold; } /* Alert */
 code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
 code span.at { color: #7d9029; } /* Attribute */
 code span.bn { color: #40a070; } /* BaseN */
-code span.bu { } /* BuiltIn */
+code span.bu { color: #644a9b; font-weight: bold; } /* BuiltIn */
 code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
 code span.ch { color: #4070a0; } /* Char */
 code span.cn { color: #880000; } /* Constant */
@@ -143,7 +143,7 @@ code span.er { color: #ff0000; font-weight: bold; } /* Error */
 code span.ex { } /* Extension */
 code span.fl { color: #40a070; } /* Float */
 code span.fu { color: #06287e; } /* Function */
-code span.im { } /* Import */
+code span.im { color: #007020; font-weight: bold; } /* Import */
 code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
 code span.kw { color: #007020; font-weight: bold; } /* Keyword */
 code span.op { color: #666666; } /* Operator */


### PR DESCRIPTION
Pridal jsem highlight pro import, a jeste pro builtin, z `--highlight-style=kate`. Zkousel jsem tucny highlight pro builtin, a netucny. Ted je v tom PR tucna veze.

## Tucne

![after2](https://user-images.githubusercontent.com/442720/98115816-b3cf2180-1ea7-11eb-9bc8-e310e2906779.png)

## Netucne

![after](https://user-images.githubusercontent.com/442720/98115832-b762a880-1ea7-11eb-87fb-6bff34e9979d.png)

Fixes #413 