### PR TITLE
Better Docker, Deploy actions, Master branch is protected 

### DIFF
--- a/.github/workflows/deploy-generic.yml
+++ b/.github/workflows/deploy-generic.yml
@@ -1,0 +1,51 @@
+name: Deploy generic
+
+on: 
+  workflow_dispatch:
+    inputs:
+      host:
+        description: 'The host to which the deploy should be made'
+        required: true
+      host_path:
+        description: 'The path to which the deploy should be made'
+        required: true
+      environment_selector:
+        description: 'The build environment selector'
+        required: true
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      # two two currently available plugins for caching don't work - one doesn't work well with buildkit and one has problems accessing the cache 
+
+      -
+        name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build --target build_dist_stage -o dist --build-arg environment_selector=${{ github.event.inputs.environment_selector }} .
+
+      - name: Deploy to Aisa
+        uses: easingthemes/ssh-deploy@v2.1.5
+        env:
+            SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+            ARGS: "-avz --delete -r"
+            SOURCE: "dist/"
+            REMOTE_HOST: aisa.fi.muni.cz
+            REMOTE_USER: ${{ secrets.SSH_USER }} # warning: as of 2020-12-05 this was using Ondra B. account
+            TARGET: "ksi/github-dist-${{ github.event.inputs.host }}"
+
+      - name: Deploy via SSH from AIsa
+        uses: garygrossgarten/github-action-ssh@release
+        with:
+          command: rsync -avz --delete -r ksi/github-dist-${{ github.event.inputs.host }} ${{ github.event.inputs.host }}:${{ github.event.inputs.host_path }}
+          host: aisa.fi.muni.cz
+          username: ${{ secrets.SSH_USER }}
+          privateKey: ${{ secrets.SSH_PRIVATE_KEY}}

--- a/.github/workflows/deploy-test-dev-by-comment.yml
+++ b/.github/workflows/deploy-test-dev-by-comment.yml
@@ -1,0 +1,18 @@
+name: Deploy to test server by comment
+
+on: 
+  issue_comment:
+    types: [created]
+
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/deploy') 
+    steps:
+      - name: Invoke KSI dev build and deploy
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Deploy to test server
+          token: ${{ secrets.PERSONAL_TOKEN }}
+

--- a/.github/workflows/deploy-test-dev.yml
+++ b/.github/workflows/deploy-test-dev.yml
@@ -1,0 +1,19 @@
+name: Deploy to test server
+
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - integration
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke KSI dev build and deploy
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Deploy generic
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          inputs: '{ "host": "ksi-dev", "host_path": "/var/www/ksi-dev", "environment_selector": "remote_dev" }'
+

--- a/.github/workflows/deploy-test-prod.yml
+++ b/.github/workflows/deploy-test-prod.yml
@@ -1,0 +1,18 @@
+name: Deploy to production server
+
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke KSI dev build and deploy
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Deploy generic
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          inputs: '{ "host": "ksi", "host_path": "/var/www/ksi", "environment_selector": "production" }'

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,20 @@
+on: 
+  issue_comment:
+    types: [created]
+name: Automatic Rebase
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout the latest code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Automatic Rebase
+      uses: cirrus-actions/rebase@1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've implemented a better Dockerfile for build and also automatic actions that allow deploy.

The tutorial how to build using docker was updated in the Readme.

Four new actions were added:
- rebase. When you type `/rebase` in PR, it will trigger automatic rebase. This rebase might fail, if there are problems, however as a first try for low effort rebasing it's perfect.

Auto-build and deploys were added.
  - When you deploy to `master` branch, the new state is built and deployed to `production` (kleobis).
  - When you deploy to `integration` branch, the new state is built and deployed to dev server (`kyzikos`).
  - When you type `/deploy` in PR, it will automatically trigger deploy of the source branch of the PR to dev server.
The build takes around 4 minutes and currently it's not being cached. Caching it could speed it up to about 15 seconds, but both premade github actions offering this functionality are not working for us.

Master is now protected. If you want to commit to master, you should do PR and have at least 1 review. If you are admin, you and override this restriction.